### PR TITLE
Balance MedMNIST totals across pseudo-label classes

### DIFF
--- a/data_generate/run_generate_medmnist.sh
+++ b/data_generate/run_generate_medmnist.sh
@@ -17,11 +17,11 @@ for dataset in "${datasets[@]}"; do
         --dataset_path=${imagenet_path} \
         --output_dir=../data/${dataset} \
         --file_prefix=resnet18_${dataset}_unified_curated \
-        --subset_size=500000 \
         --batch_size=1024 \
         --num_augmentations=5 \
         --w_sens=0.5 \
         --w_pot=0.5 \
-        --samples_per_class=50 \
+        --total_candidate_pool=25600 \
+        --total_samples=5120 \
         --num_groups=4
 done


### PR DESCRIPTION
## Summary
- add CLI options to target total candidate pools and curated sample counts and compute even per-class quotas automatically
- enforce quota-aware candidate pooling and selection so pseudo-label classes stay balanced while respecting the overall totals
- update the MedMNIST generation script to request 25,600 candidates and 5,120 curated samples per dataset

## Testing
- python -m compileall data_generate/generate_data.py

------
https://chatgpt.com/codex/tasks/task_e_68ca025a77f0832aae6b22438bacfb9f