### PR TITLE
Ensure per-class sampling rebalances to total target

### DIFF
--- a/data_generate/generate_data.py
+++ b/data_generate/generate_data.py
@@ -323,6 +323,15 @@ class PerClassSampleSelector:
                 if limit is not None
             )
 
+        if (
+            target_total is None
+            and self.default_limit is not None
+            and self.default_limit > 0
+        ):
+            observed_classes = len(self.entries_by_class)
+            if observed_classes > 0:
+                target_total = self.default_limit * observed_classes
+
         if target_total is None and effective_global_cap is not None:
             target_total = effective_global_cap
         elif target_total is not None and effective_global_cap is not None:


### PR DESCRIPTION
## Summary
- ensure PerClassSampleSelector computes a target total even when only a default per-class limit is provided
- use observed class count with the default limit to drive cross-class reallocation so total curated samples stay at the desired amount

## Testing
- python -m compileall data_generate/generate_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c8f08ca0832abbe6ecdbffdf10eb